### PR TITLE
Add CI/CD pipeline for AWS Fargate deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,165 @@
+name: Deploy to AWS Fargate
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Image tag to deploy (defaults to git SHA)"
+        required: false
+        default: ""
+
+permissions:
+  id-token: write   # required for OIDC → AWS role assumption
+  contents: read
+
+env:
+  AWS_REGION: us-east-1
+  ECR_REPO_APP: eventstracker/app
+  ECS_CLUSTER: eventstracker-prod
+  ECS_SERVICE_APP: eventstracker-prod-app
+  ECS_SERVICE_CONFIG: eventstracker-prod-config-server
+  CONTAINER_NAME: eventstracker
+
+jobs:
+  # ── Build & Test ─────────────────────────────────────────────────────────────
+  build:
+    name: Build and test
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:15-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: eventstracker_db
+        ports:
+          - 5445:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+      rabbitmq:
+        image: rabbitmq:3-management-alpine
+        ports:
+          - 5672:5672
+        options: >-
+          --health-cmd "rabbitmq-diagnostics -q check_running"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: "21"
+          distribution: temurin
+          cache: maven
+
+      - name: Check formatting
+        run: ./mvnw spotless:check -B
+
+      - name: Build and test
+        run: ./mvnw verify -B
+        env:
+          SPRING_DATASOURCE_URL: jdbc:postgresql://localhost:5445/eventstracker_db
+          SPRING_DATASOURCE_USERNAME: postgres
+          SPRING_DATASOURCE_PASSWORD: postgres
+          SPRING_RABBITMQ_HOST: localhost
+          SPRING_RABBITMQ_PORT: 5672
+          SPRING_RABBITMQ_USERNAME: guest
+          SPRING_RABBITMQ_PASSWORD: guest
+          SPRING_CLOUD_CONFIG_ENABLED: "false"
+
+  # ── Build & push Docker image ─────────────────────────────────────────────────
+  docker:
+    name: Build and push image
+    runs-on: ubuntu-latest
+    needs: build
+    outputs:
+      image_tag: ${{ steps.meta.outputs.image_tag }}
+      image_uri: ${{ steps.meta.outputs.image_uri }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve image tag
+        id: meta
+        run: |
+          TAG="${{ github.event.inputs.image_tag }}"
+          if [ -z "$TAG" ]; then
+            TAG="${{ github.sha }}"
+          fi
+          echo "image_tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Log in to ECR
+        id: ecr_login
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ steps.ecr_login.outputs.registry }}/${{ env.ECR_REPO_APP }}:${{ steps.meta.outputs.image_tag }}
+            ${{ steps.ecr_login.outputs.registry }}/${{ env.ECR_REPO_APP }}:latest
+          cache-from: type=registry,ref=${{ steps.ecr_login.outputs.registry }}/${{ env.ECR_REPO_APP }}:latest
+          cache-to: type=inline
+
+      - name: Set image URI output
+        id: uri
+        run: |
+          echo "image_uri=${{ steps.ecr_login.outputs.registry }}/${{ env.ECR_REPO_APP }}:${{ steps.meta.outputs.image_tag }}" >> "$GITHUB_OUTPUT"
+
+  # ── Deploy to ECS Fargate ────────────────────────────────────────────────────
+  deploy:
+    name: Deploy to Fargate
+    runs-on: ubuntu-latest
+    needs: docker
+    environment: production
+
+    steps:
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Download current task definition
+        run: |
+          aws ecs describe-task-definition \
+            --task-definition eventstracker-prod-app \
+            --query taskDefinition \
+            > task-def.json
+
+      - name: Update image in task definition
+        id: task_def
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: task-def.json
+          container-name: ${{ env.CONTAINER_NAME }}
+          image: ${{ needs.docker.outputs.image_uri }}
+
+      - name: Deploy to ECS
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        with:
+          task-definition: ${{ steps.task_def.outputs.task-definition }}
+          service: ${{ env.ECS_SERVICE_APP }}
+          cluster: ${{ env.ECS_CLUSTER }}
+          wait-for-service-stability: true
+          # Circuit breaker in the ECS service will auto-rollback on failure


### PR DESCRIPTION
## Summary
This PR introduces a complete CI/CD pipeline using GitHub Actions to automate building, testing, and deploying the EventsTracker application to AWS Fargate.

## Key Changes
- **Build & Test Job**: Runs Maven build and tests against PostgreSQL 15 and RabbitMQ services, including code formatting checks via Spotless
- **Docker Build Job**: Builds and pushes Docker images to AWS ECR with support for manual image tag override via workflow dispatch
- **Deploy Job**: Automatically deploys the new image to ECS Fargate with task definition updates and service stability checks
- **AWS OIDC Integration**: Uses OpenID Connect for secure, keyless AWS authentication instead of static credentials
- **Conditional Deployment**: Deploy job requires production environment approval and only runs after successful build and Docker push

## Notable Implementation Details
- Supports both automatic deployments on push to master and manual deployments via `workflow_dispatch` with custom image tags
- Uses Docker layer caching from ECR registry to optimize build times
- Includes health checks for PostgreSQL and RabbitMQ services during testing
- Disables Spring Cloud Config during tests to avoid external dependencies
- ECS service has circuit breaker enabled for automatic rollback on deployment failures
- Outputs image URI from Docker job for use in downstream deployment step

https://claude.ai/code/session_01GwQmcLzX4dJnHsumTx9GZD